### PR TITLE
remove dependency on python-keystoneclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ FROM registry
 MAINTAINER Hugo Duncan <hugo@palletops.com>
 
 # Add the swift support
-RUN ["pip", "install", "docker-registry-driver-swift", "python-keystoneclient"]
+RUN ["pip", "install", "docker-registry-driver-swift"]


### PR DESCRIPTION
bacongobbler/docker-registry-driver-swift@aead0cd adds this dependency back, so it's no longer required.
